### PR TITLE
Fix xdebug installation

### DIFF
--- a/PHP7-apache-debug/Dockerfile
+++ b/PHP7-apache-debug/Dockerfile
@@ -1,7 +1,7 @@
 FROM dpfaffenbauer/pimcore:PHP7-apache
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      autoconf automake libtool nasm make pkg-config libz-dev build-essential g++ \
+      autoconf automake libtool nasm make pkg-config libz-dev build-essential g++ iproute2 \
     && pecl install xdebug redis imagick \
     && docker-php-ext-enable xdebug \
     && apt-get autoremove -y \

--- a/PHP7.1-apache-debug/Dockerfile
+++ b/PHP7.1-apache-debug/Dockerfile
@@ -1,7 +1,7 @@
 FROM dpfaffenbauer/pimcore:PHP7.1-apache
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      autoconf automake libtool nasm make pkg-config libz-dev build-essential g++ \
+      autoconf automake libtool nasm make pkg-config libz-dev build-essential g++ iproute2 \
     && pecl install xdebug \
     && docker-php-ext-enable xdebug \
     && apt-get autoremove -y \

--- a/PHP7.1-apache-debug/Dockerfile
+++ b/PHP7.1-apache-debug/Dockerfile
@@ -21,4 +21,3 @@ ENV PHP_DEBUG 1
 COPY entrypoint.sh /usr/local/bin
 RUN chmod +x /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["apache2-foreground"]

--- a/PHP7.1-apache-debug/Dockerfile
+++ b/PHP7.1-apache-debug/Dockerfile
@@ -21,3 +21,4 @@ ENV PHP_DEBUG 1
 COPY entrypoint.sh /usr/local/bin
 RUN chmod +x /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/PHP7.2-apache-debug/Dockerfile
+++ b/PHP7.2-apache-debug/Dockerfile
@@ -1,7 +1,7 @@
 FROM dpfaffenbauer/pimcore:PHP7.2-apache
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      autoconf automake libtool nasm make pkg-config libz-dev build-essential g++ \
+      autoconf automake libtool nasm make pkg-config libz-dev build-essential g++ iproute2 \
     && pecl install xdebug \
     && docker-php-ext-enable xdebug \
     && apt-get autoremove -y \


### PR DESCRIPTION
Entrypoint.sh fails, because /sbin/ip is missing, installing iproute package fixes it.